### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/moneyforward-exporter/security/code-scanning/14](https://github.com/legnoh/moneyforward-exporter/security/code-scanning/14)

To fix the CodeQL error, we should explicitly set the `permissions` key for the workflow or for the job(s) to restrict the GITHUB_TOKEN permissions to the minimal level required. For this workflow, all steps interact with Docker Hub and build but do not require write access to the repository, so setting `contents: read` is safe and recommended. The most straightforward approach is to add a `permissions` block at the root of the workflow (above `jobs:`), which applies to all jobs unless overridden in specific jobs. No additional methods or imports are needed; just a single block addition in `.github/workflows/ci.yml` above the `jobs:` section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
